### PR TITLE
Add tests for strictness profiles and media iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ Use a single flag everywhere: `--strictness {strict,normal,loose}`.
 ## Development
 
 ### Tests
-Tiny tests ensure config integrity and basic environment sanity.
+Tiny tests ensure config integrity and basic environment sanity. Run them from the
+repository root with [pytest](https://docs.pytest.org/):
 
 ```bash
 pip install pytest

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+from config import get_profile
+
+@pytest.mark.parametrize(
+    "name, thresholds",
+    [
+        ("strict", [0.80, 0.90, 0.95]),
+        ("normal", [0.70, 0.80, 0.92]),
+        ("loose", [0.60, 0.70, 0.90]),
+    ],
+)
+def test_get_profile_thresholds(name, thresholds):
+    profile = get_profile(name)
+    assert profile.mtcnn_thresholds == thresholds

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Stub heavy dependencies before importing main
+sys.modules['torch'] = SimpleNamespace(
+    cuda=SimpleNamespace(is_available=lambda: False),
+    backends=SimpleNamespace(mps=SimpleNamespace(is_available=lambda: False)),
+)
+sys.modules['facenet_pytorch'] = SimpleNamespace(MTCNN=object)
+
+import main  # after stubbing
+
+
+def test_iter_media_filters_images_videos(tmp_path):
+    (tmp_path / 'a.jpg').touch()
+    (tmp_path / 'b.txt').touch()
+    (tmp_path / 'c.mp4').touch()
+    sub = tmp_path / 'sub'
+    sub.mkdir()
+    (sub / 'd.PNG').touch()
+    (sub / 'e.mov').touch()
+    (sub / 'f.doc').touch()
+
+    expected = {
+        tmp_path / 'a.jpg',
+        tmp_path / 'c.mp4',
+        sub / 'd.PNG',
+        sub / 'e.mov',
+    }
+    result = set(main.iter_media(tmp_path))
+    assert result == expected


### PR DESCRIPTION
## Summary
- add unit tests covering `config.get_profile` thresholds
- test `main.iter_media` to ensure only image and video files are yielded
- document running `pytest` in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3b0c5ad34832ea58c127f323f72bd