### PR TITLE
Clean up split_clusters and remove unused import

### DIFF
--- a/split_clusters.py
+++ b/split_clusters.py
@@ -12,7 +12,6 @@ import os
 import re
 import shutil
 from pathlib import Path
-from typing import Optional
 
 
 def safe_name(name: str) -> str:
@@ -49,7 +48,14 @@ def main() -> None:
         reader = csv.DictReader(f)
         for row in reader:
             p = (row.get("path") or row.get("crop_path") or row.get("file") or row.get("image") or "").strip()
-            cl = (row.get("cluster") or row.get("cluster_id") or row.get("pred_label") or row.get("label") or row.get("prediction") or "").strip()
+            cl = (
+                row.get("cluster")
+                or row.get("cluster_id")
+                or row.get("pred_label")
+                or row.get("label")
+                or row.get("prediction")
+                or ""
+            ).strip()
             if not p or not cl:
                 continue
             src = Path(p).expanduser()


### PR DESCRIPTION
## Summary
- format `cl` selection into a multi-line expression
- drop unused Optional import

## Testing
- `python -m py_compile split_clusters.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3b8071564832e8af4a3a52bd72db4