### PR TITLE
Handle optional images in embedding

### DIFF
--- a/embedding_utils.py
+++ b/embedding_utils.py
@@ -35,9 +35,9 @@ def batched(iterable: Iterable, n: int):
         yield batch
 
 
-def load_images(paths: List[Path]) -> List[Image.Image]:
+def load_images(paths: List[Path]) -> List[Optional[Image.Image]]:
     """Load images from *paths* returning ``None`` for failures."""
-    out: List[Image.Image] = []
+    out: List[Optional[Image.Image]] = []
     for p in paths:
         try:
             out.append(Image.open(p).convert("RGB"))
@@ -47,12 +47,13 @@ def load_images(paths: List[Path]) -> List[Image.Image]:
 
 
 def embed_images(
-    imgs: List[Image.Image],
+    imgs: List[Optional[Image.Image]],
     batch_size: int,
     device: Optional[str] = None,
 ) -> np.ndarray:
     """Compute FaceNet embeddings for *imgs*.
 
+    ``None`` entries are skipped but still reserve a row in the output array.
     Images are resized to 160x160 RGB and processed in batches. The returned
     array has shape ``(N, 512)`` where ``N`` is ``len(imgs)``.
     """

--- a/predict_face.py
+++ b/predict_face.py
@@ -9,13 +9,14 @@ import argparse
 import csv
 import json
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import numpy as np
 import joblib
 
 from config import get_profile
 from embedding_utils import embed_images, get_device, load_images
+from PIL import Image
 
 IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.bmp', '.tif', '.tiff', '.webp'}
 
@@ -57,7 +58,7 @@ def main():
     if not paths:
         raise SystemExit(f"No images found under {in_dir}")
 
-    imgs = load_images(paths)
+    imgs: List[Optional[Image.Image]] = load_images(paths)
     X = embed_images(imgs, device=device, batch_size=prof.embed_batch)
 
     # Predict

--- a/train_face_classifier.py
+++ b/train_face_classifier.py
@@ -12,7 +12,7 @@ Respects --strictness profile from config.py to set embedding batch size.
 import argparse
 import json
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
@@ -25,6 +25,7 @@ import joblib
 
 from config import get_profile
 from embedding_utils import embed_images, get_device, load_images
+from PIL import Image
 
 IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.bmp', '.tif', '.tiff', '.webp'}
 
@@ -81,7 +82,7 @@ def main():
         raise SystemExit(f"No images found under {data_dir}")
 
     print(f"[INFO] Found {len(paths)} images across {len(set(y))} classes.")
-    imgs = load_images(paths)
+    imgs: List[Optional[Image.Image]] = load_images(paths)
     X = embed_images(imgs, device=device, batch_size=prof.embed_batch)
 
     # Guard for tiny classes in KNN


### PR DESCRIPTION
## Summary
- Allow `load_images` to return optional PIL images for failures
- Accept optional images in `embed_images` and skip missing entries
- Update prediction and training scripts to handle optional image lists

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3b8725cac832eb9476afc44dc81c9