### PR TITLE
Refactor device selection to use shared get_device utility

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,12 +22,12 @@ try:
 except Exception:
     cv2 = None
 
-import torch
 from PIL import Image
 from facenet_pytorch import MTCNN
 
 # Import strictness profile
 from config import get_profile
+from embedding_utils import get_device
 
 IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.bmp', '.tif', '.tiff', '.webp'}
 VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.m4v'}
@@ -101,14 +101,7 @@ def main():
     prof = get_profile(args.strictness)
 
     # Select device
-    device = args.device
-    if device is None:
-        if torch.cuda.is_available():
-            device = "cuda"
-        elif getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
-            device = "mps"
-        else:
-            device = "cpu"
+    device = get_device(args.device)
     print(f"[INFO] Using device: {device}")
 
     input_dir = Path(args.input).expanduser().resolve()

--- a/verify_crops.py
+++ b/verify_crops.py
@@ -12,10 +12,10 @@ from typing import List
 
 import numpy as np
 from PIL import Image
-import torch
 from facenet_pytorch import MTCNN
 
 from config import get_profile
+from embedding_utils import get_device
 
 def ensure_dir(p: Path):
     p.mkdir(parents=True, exist_ok=True)
@@ -37,14 +37,7 @@ def main():
     min_prob = prof.min_prob if args.min_prob is None else float(args.min_prob)
     min_size = prof.min_size if args.min_size is None else int(args.min_size)
 
-    device = args.device
-    if device is None:
-        if torch.cuda.is_available():
-            device = "cuda"
-        elif getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
-            device = "mps"
-        else:
-            device = "cpu"
+    device = get_device(args.device)
     print(f"[INFO] Using device: {device}")
 
     crops_dir = Path(args.crops_dir).expanduser().resolve()


### PR DESCRIPTION
## Summary
- Use `embedding_utils.get_device` in `main.py` and `verify_crops.py` instead of duplicating device detection logic.
- Import the shared utility in both scripts and remove redundant Torch checks.
- Confirm that both scripts continue to log the selected device.

## Testing
- `pytest -q`
- `python - <<'PY'
import sys, types, tempfile, pathlib
sys.path.insert(0, str(pathlib.Path('.').resolve()))
sys.modules['torch'] = types.SimpleNamespace(
    cuda=types.SimpleNamespace(is_available=lambda: False),
    backends=types.SimpleNamespace(mps=types.SimpleNamespace(is_available=lambda: False)),
)
sys.modules['facenet_pytorch'] = types.SimpleNamespace(
    MTCNN=lambda **kwargs: types.SimpleNamespace(detect=lambda img: (None, None)),
    InceptionResnetV1=object,
)
import main
inp = tempfile.mkdtemp()
outp = tempfile.mkdtemp()
import os
sys.argv = ['main.py', '--input', inp, '--output', outp]
main.main()
PY`
- `python - <<'PY'
import sys, types, tempfile, pathlib
sys.path.insert(0, str(pathlib.Path('.').resolve()))
sys.modules['torch'] = types.SimpleNamespace(
    cuda=types.SimpleNamespace(is_available=lambda: False),
    backends=types.SimpleNamespace(mps=types.SimpleNamespace(is_available=lambda: False)),
)
sys.modules['facenet_pytorch'] = types.SimpleNamespace(
    MTCNN=lambda **kwargs: types.SimpleNamespace(detect=lambda img: (None, None)),
    InceptionResnetV1=object,
)
import verify_crops
inp = tempfile.mkdtemp()
sys.argv = ['verify_crops.py', inp]
verify_crops.main()
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b3c0cae7c8832eb0a5240b869a97c8