### PR TITLE
refactor: switch to logging framework

### DIFF
--- a/report.py
+++ b/report.py
@@ -20,6 +20,7 @@ import json
 from collections import Counter, defaultdict
 from pathlib import Path
 from statistics import mean
+import logging
 
 
 def count_images_in_dir(p: Path) -> int:
@@ -35,6 +36,9 @@ def read_csv_rows(path: Path):
         return list(csv.reader(f))
 
 
+logger = logging.getLogger(__name__)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Summarize FaceFind outputs and write a report JSON")
     parser.add_argument("--outputs", default="outputs", help="Outputs root (default: outputs)")
@@ -43,6 +47,7 @@ def main():
     parser.add_argument("--save-json", default=None, help="Where to save the JSON report (default: outputs/report.json)")
     args = parser.parse_args()
 
+    logging.basicConfig(level=logging.INFO)
     outputs = Path(args.outputs).expanduser().resolve()
     models = Path(args.models).expanduser().resolve()
     preds_csv = Path(args.predictions).expanduser().resolve() if args.predictions else (outputs / "predictions.csv")
@@ -127,8 +132,8 @@ def main():
     save_path.parent.mkdir(parents=True, exist_ok=True)
     with save_path.open("w", encoding="utf-8") as f:
         json.dump(report, f, indent=2)
-    print(json.dumps(report, indent=2))
-    print(f"[INFO] Wrote report → {save_path}")
+    logger.info(json.dumps(report, indent=2))
+    logger.info("Wrote report → %s", save_path)
 
 
 if __name__ == "__main__":

--- a/split_clusters.py
+++ b/split_clusters.py
@@ -14,6 +14,7 @@ import argparse
 import csv
 import os
 import shutil
+import logging
 from pathlib import Path
 
 IMAGE_COL_CANDIDATES = ("path", "file", "image")
@@ -37,6 +38,9 @@ def place(dst_root: Path, label: str, src: Path, copy: bool) -> None:
         shutil.copy2(src, dst)
 
 
+logger = logging.getLogger(__name__)
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description="Split images into folders by cluster/prediction")
     ap.add_argument("csv_path", help="CSV with image path + cluster/label columns")
@@ -45,6 +49,7 @@ def main() -> None:
     ap.add_argument("--rel-root", default=None, help="Optional root to resolve relative CSV paths")
     args = ap.parse_args()
 
+    logging.basicConfig(level=logging.INFO)
     csv_path = Path(args.csv_path).expanduser().resolve()
     out_dir = Path(args.out_dir).expanduser().resolve()
     ensure_dir(out_dir)
@@ -92,8 +97,8 @@ def main() -> None:
         place(out_dir, label, p, copy=args.copy)
         placed += 1
 
-    print(f"[DONE] Placed: {placed}, Skipped: {skipped}")
-    print(f"[OUT] {out_dir}")
+    logger.info("Placed: %d, Skipped: %d", placed, skipped)
+    logger.info("Out dir: %s", out_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace ad-hoc prints with `logging` calls across CLI utilities
- add basic logging configuration for scripts and import-time warnings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b61d1084d4832eba08722912446580