### PR TITLE
refactor common helpers into reusable utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ pytest
 
 ### Repo Layout
 - `facefind/`: package with CLI entry points and shared modules.
+  - `utils.py`: small reusable helpers like `ensure_dir` and `IMAGE_EXTS`.
 - `models/`: trained classifier artifacts.
 - `outputs/`: crops, manifests, clusters, predictions, etc.
 - `tests/`: small `pytest` suite.

--- a/facefind/apply_predictions.py
+++ b/facefind/apply_predictions.py
@@ -25,9 +25,7 @@ IMAGE_COLS = ("path", "file", "image")
 LABEL_COLS = ("label", "prediction")
 PROB_COLS = ("prob", "score", "confidence")
 
-
-def ensure_dir(p: Path) -> None:
-    p.mkdir(parents=True, exist_ok=True)
+from facefind.utils import ensure_dir
 
 
 def sanitize_label(label: str) -> str:

--- a/facefind/gui/utils.py
+++ b/facefind/gui/utils.py
@@ -2,9 +2,7 @@ import os
 import shutil
 from pathlib import Path
 
-
-def ensure_dir(p: Path):
-    Path(p).mkdir(parents=True, exist_ok=True)
+from facefind.utils import ensure_dir
 
 
 def unique_path(dst: Path) -> Path:

--- a/facefind/main.py
+++ b/facefind/main.py
@@ -13,6 +13,7 @@ from PIL import Image, ImageOps
 
 from facefind.config import get_profile
 from facefind.embedding_utils import get_device
+from facefind.utils import IMAGE_EXTS, ensure_dir, is_image
 
 # Optional dependency: OpenCV; used only for video paths.
 try:
@@ -26,13 +27,7 @@ except Exception:  # pragma: no cover
 logger = logging.getLogger(__name__)
 
 
-IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp"}
 VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".m4v"}
-
-
-def is_image(p: Path) -> bool:
-    return p.suffix.lower() in IMAGE_EXTS
-
 
 def is_video(p: Path) -> bool:
     return p.suffix.lower() in VIDEO_EXTS
@@ -43,11 +38,6 @@ def iter_media(root: Path) -> Iterator[Path]:
     for p in sorted(root.rglob("*")):
         if p.is_file() and (is_image(p) or is_video(p)):
             yield p
-
-
-def ensure_dir(p: Path) -> None:
-    p.mkdir(parents=True, exist_ok=True)
-
 
 def read_image_pil_rgb(path: Path) -> Image.Image:
     """Read still image via PIL and auto-fix EXIF orientation."""

--- a/facefind/predict_face.py
+++ b/facefind/predict_face.py
@@ -25,15 +25,9 @@ from PIL import Image
 
 from facefind.embedding_utils import embed_images, get_device, load_images
 from facefind.io_schema import PREDICTIONS_SCHEMA, SCHEMA_MAGIC
+from facefind.utils import is_image
 
 logger = logging.getLogger(__name__)
-
-
-IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp"}
-
-
-def is_image(p: Path) -> bool:
-    return p.is_file() and p.suffix.lower() in IMAGE_EXTS
 
 
 def list_images(root: Path) -> List[Path]:

--- a/facefind/split_clusters.py
+++ b/facefind/split_clusters.py
@@ -20,9 +20,7 @@ from pathlib import Path
 IMAGE_COL_CANDIDATES = ("path", "file", "image")
 LABEL_COL_CANDIDATES = ("cluster", "label", "prediction")
 
-
-def ensure_dir(p: Path) -> None:
-    p.mkdir(parents=True, exist_ok=True)
+from facefind.utils import ensure_dir
 
 
 def place(dst_root: Path, label: str, src: Path, copy: bool) -> None:

--- a/facefind/train_face_classifier.py
+++ b/facefind/train_face_classifier.py
@@ -30,10 +30,9 @@ from sklearn.svm import LinearSVC
 
 from facefind.config import get_profile
 from facefind.embedding_utils import embed_images, get_device, load_images
+from facefind.utils import IMAGE_EXTS
 
 logger = logging.getLogger(__name__)
-
-IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp"}
 
 
 def list_images_with_labels(root: Path) -> Tuple[List[Path], List[int], Dict[int, str]]:

--- a/facefind/utils.py
+++ b/facefind/utils.py
@@ -1,0 +1,27 @@
+"""Shared utility helpers for FaceFind scripts.
+
+This module centralizes small helpers used across multiple scripts:
+
+* :data:`IMAGE_EXTS` – set of supported image file extensions.
+* :func:`is_image` – quick predicate for image paths.
+* :func:`ensure_dir` – create a directory tree if it doesn't exist.
+
+Import these helpers instead of redefining them in each script so that
+future tools stay consistent.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+# Common image file extensions supported by FaceFind
+IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp"}
+
+
+def is_image(p: Path) -> bool:
+    """Return True if *p* has an image file extension."""
+    return p.suffix.lower() in IMAGE_EXTS
+
+
+def ensure_dir(p: Path) -> None:
+    """Ensure directory *p* exists, creating parents if needed."""
+    p.mkdir(parents=True, exist_ok=True)

--- a/facefind/verify_crops.py
+++ b/facefind/verify_crops.py
@@ -18,10 +18,7 @@ from PIL import Image
 from facefind.config import get_profile
 from facefind.embedding_utils import get_device
 from facefind.quality import passes_quality
-
-
-def ensure_dir(p: Path) -> None:
-    p.mkdir(parents=True, exist_ok=True)
+from facefind.utils import ensure_dir
 
 
 logger = logging.getLogger(__name__)

--- a/tests/test_main_helpers.py
+++ b/tests/test_main_helpers.py
@@ -5,12 +5,13 @@ import pytest
 
 import facefind.main as main
 from facefind.config import get_profile
+from facefind.utils import is_image
 
 
 def test_is_image_and_is_video_case_insensitive(tmp_path):
-    assert main.is_image(Path("a.JPG"))
-    assert main.is_image(Path("b.png"))
-    assert not main.is_image(Path("c.txt"))
+    assert is_image(Path("a.JPG"))
+    assert is_image(Path("b.png"))
+    assert not is_image(Path("c.txt"))
     assert main.is_video(Path("d.MP4"))
     assert main.is_video(Path("e.mov"))
     assert not main.is_video(Path("f.doc"))


### PR DESCRIPTION
## Summary
- add `facefind/utils.py` with `ensure_dir`, `IMAGE_EXTS`, and `is_image`
- refactor scripts to use the shared helpers
- document utilities and update tests for new imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7a7039978832ebadbfcb8b64b8115