### PR TITLE
Use context manager for opening images in verify_crops

### DIFF
--- a/facefind/verify_crops.py
+++ b/facefind/verify_crops.py
@@ -85,7 +85,8 @@ def main() -> None:
         writer.writerow(["crop_path", "prob"])
         for img_path in sorted(crops_dir.glob("*.jpg")):
             try:
-                pil = Image.open(img_path).convert("RGB")
+                with Image.open(img_path) as im:
+                    pil = im.convert("RGB")
                 boxes, probs = mtcnn.detect(pil)
                 if boxes is None or probs is None or len(boxes) == 0:
                     if reject_dir:


### PR DESCRIPTION
## Summary
- Use `with Image.open(...)` when reading crops in `verify_crops.py` to ensure file handles are closed automatically

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7a929c7d8832e93af438df9423efd