### PR TITLE
Add helper to sanitize labels for file placement

### DIFF
--- a/facefind/apply_predictions.py
+++ b/facefind/apply_predictions.py
@@ -25,15 +25,7 @@ IMAGE_COLS = ("path", "file", "image")
 LABEL_COLS = ("label", "prediction")
 PROB_COLS = ("prob", "score", "confidence")
 
-from facefind.utils import ensure_dir
-
-
-def sanitize_label(label: str) -> str:
-    label = (label or "").strip()
-    if not label:
-        return "unknown"
-    # Avoid path traversal / separators
-    return label.replace(os.sep, "_")
+from facefind.utils import ensure_dir, sanitize_label
 
 
 def unique_dst(dst: Path) -> Path:
@@ -148,19 +140,21 @@ def main():
                 missing += 1
                 continue
 
+            safe_label = sanitize_label(label)
+
             if prob >= args.accept_threshold:
                 # ACCEPT
-                place(src, accept_root, label, copy=args.copy)
+                place(src, accept_root, safe_label, copy=args.copy)
                 if people_dir:
-                    place(src, people_dir, label, copy=args.copy)
+                    place(src, people_dir, safe_label, copy=args.copy)
                 accepted += 1
-                by_label_accept[sanitize_label(label)] = by_label_accept.get(sanitize_label(label), 0) + 1
+                by_label_accept[safe_label] = by_label_accept.get(safe_label, 0) + 1
 
             elif prob >= args.review_threshold:
                 # REVIEW
-                place(src, review_root, label, copy=args.copy)
+                place(src, review_root, safe_label, copy=args.copy)
                 reviewed += 1
-                by_label_review[sanitize_label(label)] = by_label_review.get(sanitize_label(label), 0) + 1
+                by_label_review[safe_label] = by_label_review.get(safe_label, 0) + 1
             else:
                 # Below review threshold → ignore (soft reject)
                 rejected += 1

--- a/facefind/split_clusters.py
+++ b/facefind/split_clusters.py
@@ -20,11 +20,12 @@ from pathlib import Path
 IMAGE_COL_CANDIDATES = ("path", "file", "image")
 LABEL_COL_CANDIDATES = ("cluster", "label", "prediction")
 
-from facefind.utils import ensure_dir
+from facefind.utils import ensure_dir, sanitize_label
 
 
 def place(dst_root: Path, label: str, src: Path, copy: bool) -> None:
-    dst_dir = dst_root / (label or "unknown")
+    safe_label = sanitize_label(label)
+    dst_dir = dst_root / safe_label
     ensure_dir(dst_dir)
     dst = dst_dir / src.name
     try:
@@ -92,7 +93,8 @@ def main() -> None:
             skipped += 1
             continue
 
-        place(out_dir, label, p, copy=args.copy)
+        safe_label = sanitize_label(label)
+        place(out_dir, safe_label, p, copy=args.copy)
         placed += 1
 
     logger.info("Placed: %d, Skipped: %d", placed, skipped)

--- a/facefind/utils.py
+++ b/facefind/utils.py
@@ -12,6 +12,7 @@ future tools stay consistent.
 from __future__ import annotations
 
 from pathlib import Path
+import os
 
 # Common image file extensions supported by FaceFind
 IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp"}
@@ -25,3 +26,13 @@ def is_image(p: Path) -> bool:
 def ensure_dir(p: Path) -> None:
     """Ensure directory *p* exists, creating parents if needed."""
     p.mkdir(parents=True, exist_ok=True)
+
+
+def sanitize_label(label: str) -> str:
+    """Normalize *label* for safe filesystem usage."""
+    label = (label or "").strip()
+    if not label:
+        return "unknown"
+    # Avoid path traversal / separators
+    return label.replace(os.sep, "_")
+


### PR DESCRIPTION
## Summary
- add reusable `sanitize_label` helper
- sanitize labels when placing files and pass sanitized labels to `place`
- import and use `sanitize_label` in prediction and cluster scripts

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b7a9f38388832e810f0f715944f830