### PR TITLE
Enhance label sanitization and adjust usage

### DIFF
--- a/facefind/apply_predictions.py
+++ b/facefind/apply_predictions.py
@@ -15,17 +15,17 @@ CSV header is flexible:
 
 import argparse
 import csv
+import logging
 import os
 import shutil
-import logging
 from pathlib import Path
 from typing import Dict, Optional, Tuple
+
+from facefind.utils import ensure_dir, sanitize_label
 
 IMAGE_COLS = ("path", "file", "image")
 LABEL_COLS = ("label", "prediction")
 PROB_COLS = ("prob", "score", "confidence")
-
-from facefind.utils import ensure_dir, sanitize_label
 
 
 def unique_dst(dst: Path) -> Path:
@@ -43,8 +43,7 @@ def unique_dst(dst: Path) -> Path:
         i += 1
 
 
-def place(src: Path, dst_root: Path, label: str, copy: bool) -> Path:
-    safe_label = sanitize_label(label)
+def place(src: Path, dst_root: Path, safe_label: str, copy: bool) -> Path:
     dst_dir = dst_root / safe_label
     ensure_dir(dst_dir)
     dst = unique_dst(dst_dir / src.name)

--- a/facefind/split_clusters.py
+++ b/facefind/split_clusters.py
@@ -12,19 +12,18 @@ CSV column detection (first match wins):
 """
 import argparse
 import csv
+import logging
 import os
 import shutil
-import logging
 from pathlib import Path
+
+from facefind.utils import ensure_dir, sanitize_label
 
 IMAGE_COL_CANDIDATES = ("path", "file", "image")
 LABEL_COL_CANDIDATES = ("cluster", "label", "prediction")
 
-from facefind.utils import ensure_dir, sanitize_label
 
-
-def place(dst_root: Path, label: str, src: Path, copy: bool) -> None:
-    safe_label = sanitize_label(label)
+def place(dst_root: Path, safe_label: str, src: Path, copy: bool) -> None:
     dst_dir = dst_root / safe_label
     ensure_dir(dst_dir)
     dst = dst_dir / src.name

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,25 @@
+import os
+
+from facefind.utils import sanitize_label
+
+
+def test_sanitize_label_replaces_separators():
+    label = f"foo{os.sep}bar"
+    assert sanitize_label(label) == "foo_bar"
+
+
+def test_sanitize_label_replaces_altsep(monkeypatch):
+    monkeypatch.setattr(os, "altsep", ";")
+    label = "foo;bar"
+    assert sanitize_label(label) == "foo_bar"
+
+
+def test_sanitize_label_substitute_non_alnum_default():
+    label = "foo!bar"
+    assert sanitize_label(label) == "foo_bar"
+
+
+def test_sanitize_label_strip_non_alnum():
+    assert sanitize_label("foo!bar#baz", replacement=None) == "foobarbaz"
+    # All stripped -> unknown
+    assert sanitize_label("!!!", replacement=None) == "unknown"


### PR DESCRIPTION
## Summary
- Expand `sanitize_label` to strip path separators and optionally clean other non-alphanumeric characters
- Update cluster splitting and prediction application to expect pre-sanitized labels
- Add tests for `sanitize_label`

## Testing
- `pytest`
- `ruff check facefind/utils.py facefind/split_clusters.py facefind/apply_predictions.py tests/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7aa7e7d44832eaf5f634a48f175a4