### PR TITLE
Centralize media extension lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ pytest
 
 ### Repo Layout
 - `facefind/`: package with CLI entry points and shared modules.
-  - `utils.py`: small reusable helpers like `ensure_dir` and `IMAGE_EXTS`.
+  - `utils.py`: small reusable helpers like `ensure_dir`.
+  - `file_exts.py`: shared image and video file extension sets.
 - `models/`: trained classifier artifacts.
 - `outputs/`: crops, manifests, clusters, predictions, etc.
 - `tests/`: small `pytest` suite.

--- a/facefind/file_exts.py
+++ b/facefind/file_exts.py
@@ -1,0 +1,7 @@
+"""Shared file extension sets for FaceFind."""
+
+# Common image file extensions supported by FaceFind
+IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp"}
+
+# Common video file extensions (optional)
+VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".m4v"}

--- a/facefind/main.py
+++ b/facefind/main.py
@@ -13,7 +13,8 @@ from PIL import Image, ImageOps
 
 from facefind.config import get_profile
 from facefind.embedding_utils import get_device
-from facefind.utils import IMAGE_EXTS, ensure_dir, is_image
+from facefind.file_exts import VIDEO_EXTS
+from facefind.utils import ensure_dir, is_image
 
 # Optional dependency: OpenCV; used only for video paths.
 try:
@@ -26,8 +27,6 @@ except Exception:  # pragma: no cover
 
 logger = logging.getLogger(__name__)
 
-
-VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".m4v"}
 
 def is_video(p: Path) -> bool:
     return p.suffix.lower() in VIDEO_EXTS

--- a/facefind/predict_face.py
+++ b/facefind/predict_face.py
@@ -25,15 +25,15 @@ from PIL import Image
 
 from facefind.embedding_utils import embed_images, get_device, load_images
 from facefind.io_schema import PREDICTIONS_SCHEMA, SCHEMA_MAGIC
-from facefind.utils import is_image
+from facefind.file_exts import IMAGE_EXTS
 
 logger = logging.getLogger(__name__)
 
 
 def list_images(root: Path) -> List[Path]:
-    if root.is_file() and is_image(root):
+    if root.is_file() and root.suffix.lower() in IMAGE_EXTS:
         return [root]
-    return [p for p in sorted(root.rglob("*")) if is_image(p)]
+    return [p for p in sorted(root.rglob("*")) if p.suffix.lower() in IMAGE_EXTS]
 
 
 def softmax_row(x: np.ndarray) -> np.ndarray:

--- a/facefind/report.py
+++ b/facefind/report.py
@@ -17,16 +17,18 @@ Usage:
 import argparse
 import csv
 import json
+import logging
 from collections import Counter, defaultdict
 from pathlib import Path
 from statistics import mean
-import logging
+
+from facefind.file_exts import IMAGE_EXTS
 
 
 def count_images_in_dir(p: Path) -> int:
     if not p.exists():
         return 0
-    return sum(1 for x in p.rglob("*") if x.suffix.lower() in {".jpg", ".jpeg", ".png", ".webp", ".bmp", ".tif", ".tiff"})
+    return sum(1 for x in p.rglob("*") if x.suffix.lower() in IMAGE_EXTS)
 
 
 def read_csv_rows(path: Path):

--- a/facefind/train_face_classifier.py
+++ b/facefind/train_face_classifier.py
@@ -30,7 +30,7 @@ from sklearn.svm import LinearSVC
 
 from facefind.config import get_profile
 from facefind.embedding_utils import embed_images, get_device, load_images
-from facefind.utils import IMAGE_EXTS
+from facefind.file_exts import IMAGE_EXTS
 
 logger = logging.getLogger(__name__)
 

--- a/facefind/utils.py
+++ b/facefind/utils.py
@@ -2,12 +2,11 @@
 
 This module centralizes small helpers used across multiple scripts:
 
-* :data:`IMAGE_EXTS` – set of supported image file extensions.
 * :func:`is_image` – quick predicate for image paths.
 * :func:`ensure_dir` – create a directory tree if it doesn't exist.
 
-Import these helpers instead of redefining them in each script so that
-future tools stay consistent.
+The canonical file-extension sets live in :mod:`facefind.file_exts` and are
+imported here for convenience.
 """
 from __future__ import annotations
 
@@ -15,8 +14,7 @@ import os
 import re
 from pathlib import Path
 
-# Common image file extensions supported by FaceFind
-IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp"}
+from facefind.file_exts import IMAGE_EXTS
 
 
 def is_image(p: Path) -> bool:


### PR DESCRIPTION
## Summary
- centralize image and video extension sets in new `file_exts` module
- use shared extension lists across CLI tools
- document `file_exts.py` in repo layout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7ac16630c832e8dcf2984803af5de