### PR TITLE
Wrap PIL image opens in context managers

### DIFF
--- a/facefind/main.py
+++ b/facefind/main.py
@@ -40,8 +40,9 @@ def iter_media(root: Path) -> Iterator[Path]:
 
 def read_image_pil_rgb(path: Path) -> Image.Image:
     """Read still image via PIL and auto-fix EXIF orientation."""
-    img = Image.open(path).convert("RGB")
-    return ImageOps.exif_transpose(img)
+    with Image.open(path) as img:
+        img = img.convert("RGB")
+        return ImageOps.exif_transpose(img)
 
 
 def create_mtcnn(profile, device: str) -> MTCNN:

--- a/facefind/verify_crops.py
+++ b/facefind/verify_crops.py
@@ -85,29 +85,29 @@ def main() -> None:
         writer.writerow(["crop_path", "prob"])
         for img_path in sorted(crops_dir.glob("*.jpg")):
             try:
-                with Image.open(img_path) as im:
-                    pil = im.convert("RGB")
-                boxes, probs = mtcnn.detect(pil)
-                if boxes is None or probs is None or len(boxes) == 0:
-                    if reject_dir:
-                        shutil.move(str(img_path), reject_dir / img_path.name)
-                    rejected += 1
-                    continue
+                with Image.open(img_path) as pil:
+                    pil = pil.convert("RGB")
+                    boxes, probs = mtcnn.detect(pil)
+                    if boxes is None or probs is None or len(boxes) == 0:
+                        if reject_dir:
+                            shutil.move(str(img_path), reject_dir / img_path.name)
+                        rejected += 1
+                        continue
 
-                ok, var, exposure = passes_quality(
-                    pil, min_var=args.min_var, exposure_tol=args.exposure_tol
-                )
-                if not ok:
-                    logger.debug(
-                        "Rejected %s for quality: var=%.2f exposure=%s",
-                        img_path,
-                        var,
-                        exposure,
+                    ok, var, exposure = passes_quality(
+                        pil, min_var=args.min_var, exposure_tol=args.exposure_tol
                     )
-                    if reject_dir:
-                        shutil.move(str(img_path), reject_dir / img_path.name)
-                    rejected += 1
-                    continue
+                    if not ok:
+                        logger.debug(
+                            "Rejected %s for quality: var=%.2f exposure=%s",
+                            img_path,
+                            var,
+                            exposure,
+                        )
+                        if reject_dir:
+                            shutil.move(str(img_path), reject_dir / img_path.name)
+                        rejected += 1
+                        continue
                 # Keep
                 writer.writerow([str(img_path), f"{max(probs):.4f}"])
                 f.flush()

--- a/tests/test_resource_warnings.py
+++ b/tests/test_resource_warnings.py
@@ -1,0 +1,50 @@
+import sys
+import warnings
+from types import SimpleNamespace
+
+from PIL import Image
+
+# Stub heavy dependencies before importing modules under test
+sys.modules["torch"] = SimpleNamespace(
+    cuda=SimpleNamespace(is_available=lambda: False),
+    backends=SimpleNamespace(mps=SimpleNamespace(is_available=lambda: False)),
+)
+
+class DummyMTCNN:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def detect(self, img):
+        return [[0, 0, 1, 1]], [0.9]
+
+sys.modules["facenet_pytorch"] = SimpleNamespace(MTCNN=DummyMTCNN)
+sys.modules["facefind.quality"] = SimpleNamespace(
+    passes_quality=lambda *args, **kwargs: (True, 0.0, "good")
+)
+
+import facefind.main as main
+import facefind.verify_crops as verify_crops
+
+def _no_resource_warnings(warns):
+    return [w for w in warns if issubclass(w.category, ResourceWarning)]
+
+def test_read_image_pil_rgb_no_resource_warning(tmp_path):
+    img_path = tmp_path / "sample.jpg"
+    Image.new("RGB", (4, 4)).save(img_path)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        main.read_image_pil_rgb(img_path)
+
+    assert not _no_resource_warnings(w)
+
+def test_verify_crops_no_resource_warning(tmp_path, monkeypatch):
+    img_path = tmp_path / "crop.jpg"
+    Image.new("RGB", (4, 4)).save(img_path)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        monkeypatch.setattr(sys, "argv", ["verify_crops", str(tmp_path)])
+        verify_crops.main()
+
+    assert not _no_resource_warnings(w)


### PR DESCRIPTION
## Summary
- ensure `Image.open` calls in `main.read_image_pil_rgb` and `verify_crops` use `with` statements
- add regression tests to guard against unclosed file warnings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7ad2ab090832eb2cf4d23c126dc25