### PR TITLE
refactor: centralize shared utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,10 @@ pytest
 ```
 
 ### Repo Layout
-- `facefind/`: package with CLI entry points and shared modules.
-  - `utils.py`: small reusable helpers like `ensure_dir`.
-  - `file_exts.py`: shared image and video file extension sets.
+- `utils/`: reusable helpers like `ensure_dir` and `IMAGE_EXTS`.
+- `facefind/`: package with CLI entry points and higher level utilities.
+  - `utils.py`: helpers such as `is_image` and `sanitize_label`.
+  - `file_exts.py`: shared video file extension set.
 - `models/`: trained classifier artifacts.
 - `outputs/`: crops, manifests, clusters, predictions, etc.
 - `tests/`: small `pytest` suite.

--- a/facefind/apply_predictions.py
+++ b/facefind/apply_predictions.py
@@ -21,7 +21,8 @@ import shutil
 from pathlib import Path
 from typing import Dict, Optional, Tuple
 
-from facefind.utils import ensure_dir, sanitize_label
+from facefind.utils import sanitize_label
+from utils.common import ensure_dir
 
 IMAGE_COLS = ("path", "file", "image")
 LABEL_COLS = ("label", "prediction")

--- a/facefind/file_exts.py
+++ b/facefind/file_exts.py
@@ -1,7 +1,8 @@
 """Shared file extension sets for FaceFind."""
 
-# Common image file extensions supported by FaceFind
-IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp"}
+from utils.common import IMAGE_EXTS
 
 # Common video file extensions (optional)
 VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".m4v"}
+
+__all__ = ["IMAGE_EXTS", "VIDEO_EXTS"]

--- a/facefind/gui/utils.py
+++ b/facefind/gui/utils.py
@@ -2,7 +2,7 @@ import os
 import shutil
 from pathlib import Path
 
-from facefind.utils import ensure_dir
+from utils.common import ensure_dir
 
 
 def unique_path(dst: Path) -> Path:

--- a/facefind/main.py
+++ b/facefind/main.py
@@ -14,7 +14,8 @@ from PIL import Image, ImageOps
 from facefind.config import get_profile
 from facefind.embedding_utils import get_device
 from facefind.file_exts import VIDEO_EXTS
-from facefind.utils import ensure_dir, is_image
+from facefind.utils import is_image
+from utils.common import ensure_dir
 
 # Optional dependency: OpenCV; used only for video paths.
 try:

--- a/facefind/predict_face.py
+++ b/facefind/predict_face.py
@@ -25,7 +25,7 @@ from PIL import Image
 
 from facefind.embedding_utils import embed_images, get_device, load_images
 from facefind.io_schema import PREDICTIONS_SCHEMA, SCHEMA_MAGIC
-from facefind.file_exts import IMAGE_EXTS
+from utils.common import IMAGE_EXTS
 
 logger = logging.getLogger(__name__)
 

--- a/facefind/report.py
+++ b/facefind/report.py
@@ -22,7 +22,7 @@ from collections import Counter, defaultdict
 from pathlib import Path
 from statistics import mean
 
-from facefind.file_exts import IMAGE_EXTS
+from utils.common import IMAGE_EXTS
 
 
 def count_images_in_dir(p: Path) -> int:

--- a/facefind/split_clusters.py
+++ b/facefind/split_clusters.py
@@ -17,7 +17,8 @@ import os
 import shutil
 from pathlib import Path
 
-from facefind.utils import ensure_dir, sanitize_label
+from facefind.utils import sanitize_label
+from utils.common import ensure_dir
 
 IMAGE_COL_CANDIDATES = ("path", "file", "image")
 LABEL_COL_CANDIDATES = ("cluster", "label", "prediction")

--- a/facefind/train_face_classifier.py
+++ b/facefind/train_face_classifier.py
@@ -30,7 +30,7 @@ from sklearn.svm import LinearSVC
 
 from facefind.config import get_profile
 from facefind.embedding_utils import embed_images, get_device, load_images
-from facefind.file_exts import IMAGE_EXTS
+from utils.common import IMAGE_EXTS
 
 logger = logging.getLogger(__name__)
 

--- a/facefind/utils.py
+++ b/facefind/utils.py
@@ -3,10 +3,10 @@
 This module centralizes small helpers used across multiple scripts:
 
 * :func:`is_image` – quick predicate for image paths.
-* :func:`ensure_dir` – create a directory tree if it doesn't exist.
+* :func:`sanitize_label` – normalize labels for filesystem safety.
 
-The canonical file-extension sets live in :mod:`facefind.file_exts` and are
-imported here for convenience.
+The canonical file-extension set lives in :mod:`utils.common` and is imported
+here for convenience.
 """
 from __future__ import annotations
 
@@ -14,17 +14,12 @@ import os
 import re
 from pathlib import Path
 
-from facefind.file_exts import IMAGE_EXTS
+from utils.common import IMAGE_EXTS
 
 
 def is_image(p: Path) -> bool:
     """Return True if *p* has an image file extension."""
     return p.suffix.lower() in IMAGE_EXTS
-
-
-def ensure_dir(p: Path) -> None:
-    """Ensure directory *p* exists, creating parents if needed."""
-    p.mkdir(parents=True, exist_ok=True)
 
 
 def sanitize_label(label: str, replacement: str | None = "_") -> str:

--- a/facefind/verify_crops.py
+++ b/facefind/verify_crops.py
@@ -18,7 +18,7 @@ from PIL import Image
 from facefind.config import get_profile
 from facefind.embedding_utils import get_device
 from facefind.quality import passes_quality
-from facefind.utils import ensure_dir
+from utils.common import ensure_dir
 
 
 logger = logging.getLogger(__name__)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,3 @@
+from .common import ensure_dir, IMAGE_EXTS
+
+__all__ = ["ensure_dir", "IMAGE_EXTS"]

--- a/utils/common.py
+++ b/utils/common.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp"}
+
+
+def ensure_dir(p: Path) -> None:
+    """Ensure directory *p* exists, creating parents if needed."""
+    p.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- Add `utils/common.py` with `IMAGE_EXTS` and `ensure_dir`
- Switch scripts to import shared helpers from `utils.common`
- Update documentation and clean up legacy utility definitions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7afe83fe0832e8e6ee02d1fcb4f4f