### PR TITLE
Use shared column alias constants

### DIFF
--- a/facefind/apply_predictions.py
+++ b/facefind/apply_predictions.py
@@ -24,9 +24,7 @@ from typing import Dict, Optional, Tuple
 from facefind.utils import sanitize_label
 from utils.common import ensure_dir
 
-IMAGE_COLS = ("path", "file", "image")
-LABEL_COLS = ("label", "prediction")
-PROB_COLS = ("prob", "score", "confidence")
+from facefind.io_schema import PATH_ALIASES, LABEL_ALIASES, PROB_ALIASES
 
 
 def unique_dst(dst: Path) -> Path:
@@ -68,7 +66,7 @@ def detect_headers(headers) -> Tuple[Optional[str], Optional[str], Optional[str]
                 return low[c]
         return None
 
-    return pick(IMAGE_COLS), pick(LABEL_COLS), pick(PROB_COLS)
+    return pick(PATH_ALIASES), pick(LABEL_ALIASES), pick(PROB_ALIASES)
 
 
 logger = logging.getLogger(__name__)
@@ -117,7 +115,10 @@ def main():
         reader = csv.DictReader(f)
         img_col, lab_col, prob_col = detect_headers(reader.fieldnames)
         if not img_col or not lab_col or not prob_col:
-            raise SystemExit(f"CSV must contain columns: path({IMAGE_COLS}), label({LABEL_COLS}), prob({PROB_COLS}). " f"Found: {reader.fieldnames}")
+            raise SystemExit(
+                f"CSV must contain columns: path({PATH_ALIASES}), label({LABEL_ALIASES}), prob({PROB_ALIASES}). "
+                f"Found: {reader.fieldnames}"
+            )
 
         for row in reader:
             raw_path = (row.get(img_col) or "").strip()

--- a/facefind/io_schema.py
+++ b/facefind/io_schema.py
@@ -11,3 +11,12 @@ SCHEMA_MAGIC = "# FaceFindPredictions,v1"
 PATH_ALIASES = ("path", "file", "image")
 LABEL_ALIASES = ("label", "prediction", "pred_label")
 PROB_ALIASES = ("prob", "score", "confidence")
+
+
+__all__ = [
+    "PREDICTIONS_SCHEMA",
+    "SCHEMA_MAGIC",
+    "PATH_ALIASES",
+    "LABEL_ALIASES",
+    "PROB_ALIASES",
+]

--- a/facefind/split_clusters.py
+++ b/facefind/split_clusters.py
@@ -20,8 +20,9 @@ from pathlib import Path
 from facefind.utils import sanitize_label
 from utils.common import ensure_dir
 
-IMAGE_COL_CANDIDATES = ("path", "file", "image")
-LABEL_COL_CANDIDATES = ("cluster", "label", "prediction")
+from facefind.io_schema import PATH_ALIASES, LABEL_ALIASES, PROB_ALIASES
+LABEL_CANDIDATES = ("cluster",) + LABEL_ALIASES
+_ = PROB_ALIASES
 
 
 def place(dst_root: Path, safe_label: str, src: Path, copy: bool) -> None:
@@ -67,12 +68,13 @@ def main() -> None:
                     return headers[c]
             return None
 
-        img_col = pick(IMAGE_COL_CANDIDATES)
-        lab_col = pick(LABEL_COL_CANDIDATES)
+        img_col = pick(PATH_ALIASES)
+        lab_col = pick(LABEL_CANDIDATES)
 
         if not img_col or not lab_col:
             raise SystemExit(
-                f"CSV must contain image column in {IMAGE_COL_CANDIDATES} " f"and label column in {LABEL_COL_CANDIDATES}. Found: {reader.fieldnames}"
+                f"CSV must contain image column in {PATH_ALIASES} "
+                f"and label column in {LABEL_CANDIDATES}. Found: {reader.fieldnames}"
             )
 
         rows = list(reader)


### PR DESCRIPTION
## Summary
- export alias tuples in `io_schema` for paths, labels and probabilities
- reuse the shared alias constants in `apply_predictions` and `split_clusters`
- simplify header detection and error messages using the shared constants

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7b1c1311c832e8f8b2450244b821f