### PR TITLE
Gracefully handle missing OpenCV in image quality module

### DIFF
--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,23 +1,51 @@
-from PIL import Image
+from __future__ import annotations
+
 import numpy as np
+from PIL import Image
 
 import pytest
 
-cv2 = pytest.importorskip("cv2")
+import facefind.quality as quality
 
-from facefind.quality import variance_of_laplacian, check_exposure
+try:  # pragma: no cover - test helper
+    import cv2  # type: ignore
+except ImportError:  # pragma: no cover
+    cv2 = None
 
-def test_variance_of_laplacian_sharp_vs_blur():
+
+@pytest.mark.skipif(cv2 is None, reason="OpenCV not installed")
+def test_variance_of_laplacian_sharp_vs_blur() -> None:
     sharp = np.zeros((100, 100), dtype=np.uint8)
     sharp[40:60, :] = 255
     sharp_img = Image.fromarray(sharp)
     blur_img = Image.fromarray(np.full((100, 100), 127, dtype=np.uint8))
-    assert variance_of_laplacian(sharp_img) > variance_of_laplacian(blur_img)
+    assert quality.variance_of_laplacian(sharp_img) > quality.variance_of_laplacian(blur_img)
 
-def test_check_exposure_under_over_good():
+
+@pytest.mark.skipif(cv2 is None, reason="OpenCV not installed")
+def test_check_exposure_under_over_good() -> None:
     dark = Image.fromarray(np.zeros((10, 10), dtype=np.uint8))
     bright = Image.fromarray(np.full((10, 10), 255, dtype=np.uint8))
     mid = Image.fromarray(np.full((10, 10), 127, dtype=np.uint8))
-    assert check_exposure(dark) == "under"
-    assert check_exposure(bright) == "over"
-    assert check_exposure(mid) == "good"
+    assert quality.check_exposure(dark) == "under"
+    assert quality.check_exposure(bright) == "over"
+    assert quality.check_exposure(mid) == "good"
+
+
+def test_variance_of_laplacian_requires_opencv(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(quality, "cv2", None)
+    with pytest.raises(ImportError, match="OpenCV"):
+        quality.variance_of_laplacian(Image.new("L", (1, 1)))
+
+
+def test_check_exposure_requires_opencv(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(quality, "cv2", None)
+    with pytest.raises(ImportError, match="OpenCV"):
+        quality.check_exposure(Image.new("L", (1, 1)))
+
+
+def test_passes_quality_requires_opencv(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(quality, "cv2", None)
+    with pytest.raises(ImportError, match="OpenCV"):
+        quality.passes_quality(Image.new("L", (1, 1)))
+


### PR DESCRIPTION
## Summary
- Guard OpenCV import in `quality.py` and provide clear dependency error messages
- Ensure quality routines check for OpenCV availability before running
- Add tests for missing OpenCV scenarios and retain existing quality tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7b298d35c832ebf913d3f5daaeb47