### PR TITLE
Validate device argument and enforce recognized values

### DIFF
--- a/facefind/embedding_utils.py
+++ b/facefind/embedding_utils.py
@@ -30,6 +30,9 @@ def get_device(preferred: Optional[str] = None) -> str:
     """
     if preferred:
         pref = preferred.lower()
+        allowed = {"cpu", "cuda", "mps"}
+        if pref not in allowed:
+            raise ValueError(f"Unknown device '{preferred}'. Allowed: {sorted(allowed)}")
         if pref == "cuda" and torch.cuda.is_available():
             return "cuda"
         if pref == "mps" and getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():

--- a/facefind/main.py
+++ b/facefind/main.py
@@ -131,6 +131,7 @@ def main() -> None:
     parser.add_argument(
         "--device",
         default=None,
+        choices=["cpu", "cuda", "mps"],
         help="torch device, e.g., cuda, mps, or cpu (auto if not set)",
     )
     parser.add_argument(

--- a/facefind/predict_face.py
+++ b/facefind/predict_face.py
@@ -58,6 +58,7 @@ def main() -> None:
     ap.add_argument(
         "--device",
         default=None,
+        choices=["cpu", "cuda", "mps"],
         help="torch device: mps, cuda, or cpu (auto if unset)",
     )
     ap.add_argument(

--- a/facefind/train_face_classifier.py
+++ b/facefind/train_face_classifier.py
@@ -72,7 +72,7 @@ def main():
     parser.add_argument("--data", required=True, help="Path to labeled people folder (each subfolder = class)")
     parser.add_argument("--out", default="models", help="Output directory (default: models)")
     parser.add_argument("--strictness", default="strict", choices=["strict", "normal", "loose"], help="Profile from config.py (controls embedding batch size)")
-    parser.add_argument("--device", default=None, help="torch device: cuda, mps, or cpu (auto if unset)")
+    parser.add_argument("--device", default=None, choices=["cpu", "cuda", "mps"], help="torch device: cuda, mps, or cpu (auto if unset)")
     parser.add_argument("--log-level", default="INFO", help="Logging level (e.g., DEBUG, INFO)")
     args = parser.parse_args()
 

--- a/facefind/verify_crops.py
+++ b/facefind/verify_crops.py
@@ -37,6 +37,7 @@ def main() -> None:
     parser.add_argument(
         "--device",
         default=None,
+        choices=["cpu", "cuda", "mps"],
         help="torch device: cuda, mps, or cpu (auto if unset)",
     )
     parser.add_argument(

--- a/tests/test_embedding_utils.py
+++ b/tests/test_embedding_utils.py
@@ -30,6 +30,13 @@ def test_get_device_default_cpu(monkeypatch):
     assert embedding_utils.get_device() == "cpu"
 
 
+def test_get_device_invalid():
+    import pytest
+
+    with pytest.raises(ValueError):
+        embedding_utils.get_device("bogus")
+
+
 def test_batched_chunks():
     result = list(embedding_utils.batched(range(5), 2))
     assert result == [[0, 1], [2, 3], [4]]


### PR DESCRIPTION
## Summary
- raise `ValueError` in `get_device` when an unknown device is requested
- restrict command line `--device` options to `cpu`, `cuda` or `mps`
- add regression test for invalid device selection

## Testing
- `python -m compileall -q .`
- `ruff check .` *(fails: import sorting and unused imports)*
- `black --check .` *(fails: files would be reformatted)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7b3493160832eaddcde080f0c0e16