### PR TITLE
Package io_schema and configure setuptools discovery

### DIFF
--- a/facefind/__init__.py
+++ b/facefind/__init__.py
@@ -1,3 +1,8 @@
 """FaceFind package with shared utilities and CLI entry points."""
 
-__all__ = []
+# Re-export common schema definitions for convenience when importing the
+# package directly (``import facefind``).
+from . import io_schema
+
+__all__ = ["io_schema"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ facefind-predict = "facefind.predict_face:main"
 facefind-apply = "facefind.apply_predictions:main"
 facefind-report = "facefind.report:main"
 
+[tool.setuptools.packages.find]
+include = ["facefind*"]
+
 [tool.black]
 line-length = 160
 target-version = ["py311"]


### PR DESCRIPTION
## Summary
- Re-export `io_schema` from the `facefind` package for easier imports
- Configure setuptools to discover the `facefind` package during installation

## Testing
- `pytest -q`
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_68b7b5119b48832ea5a8ebf1e9b7b4d8