### PR TITLE
refactor: centralize filesystem helpers

### DIFF
--- a/facefind/apply_predictions.py
+++ b/facefind/apply_predictions.py
@@ -21,8 +21,7 @@ import shutil
 from pathlib import Path
 from typing import Dict, Optional, Tuple
 
-from facefind.utils import sanitize_label
-from utils.common import ensure_dir
+from facefind.utils import ensure_dir, sanitize_label
 
 from facefind.io_schema import PATH_ALIASES, LABEL_ALIASES, PROB_ALIASES
 

--- a/facefind/file_exts.py
+++ b/facefind/file_exts.py
@@ -1,6 +1,6 @@
 """Shared file extension sets for FaceFind."""
 
-from utils.common import IMAGE_EXTS
+from facefind.utils import IMAGE_EXTS
 
 # Common video file extensions (optional)
 VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".m4v"}

--- a/facefind/gui/utils.py
+++ b/facefind/gui/utils.py
@@ -2,7 +2,7 @@ import os  # Needed for creating hard links
 import shutil
 from pathlib import Path
 
-from utils.common import ensure_dir
+from facefind.utils import ensure_dir
 
 
 def unique_path(dst: Path) -> Path:

--- a/facefind/main.py
+++ b/facefind/main.py
@@ -14,8 +14,7 @@ from PIL import Image, ImageOps
 from facefind.config import get_profile
 from facefind.embedding_utils import get_device
 from facefind.file_exts import VIDEO_EXTS
-from facefind.utils import is_image
-from utils.common import ensure_dir
+from facefind.utils import ensure_dir, is_image
 
 # Optional dependency: OpenCV; used only for video paths.
 try:

--- a/facefind/predict_face.py
+++ b/facefind/predict_face.py
@@ -25,7 +25,7 @@ from PIL import Image
 
 from facefind.embedding_utils import embed_images, get_device, load_images
 from facefind.io_schema import PREDICTIONS_SCHEMA, SCHEMA_MAGIC
-from utils.common import IMAGE_EXTS
+from facefind.utils import IMAGE_EXTS
 
 logger = logging.getLogger(__name__)
 

--- a/facefind/report.py
+++ b/facefind/report.py
@@ -22,7 +22,7 @@ from collections import Counter, defaultdict
 from pathlib import Path
 from statistics import mean
 
-from utils.common import IMAGE_EXTS
+from facefind.utils import IMAGE_EXTS
 
 
 def count_images_in_dir(p: Path) -> int:

--- a/facefind/split_clusters.py
+++ b/facefind/split_clusters.py
@@ -17,8 +17,7 @@ import os
 import shutil
 from pathlib import Path
 
-from facefind.utils import sanitize_label
-from utils.common import ensure_dir
+from facefind.utils import ensure_dir, sanitize_label
 
 from facefind.io_schema import PATH_ALIASES, LABEL_ALIASES, PROB_ALIASES
 LABEL_CANDIDATES = ("cluster",) + LABEL_ALIASES

--- a/facefind/train_face_classifier.py
+++ b/facefind/train_face_classifier.py
@@ -30,7 +30,7 @@ from sklearn.svm import LinearSVC
 
 from facefind.config import get_profile
 from facefind.embedding_utils import embed_images, get_device, load_images
-from utils.common import IMAGE_EXTS
+from facefind.utils import IMAGE_EXTS
 
 logger = logging.getLogger(__name__)
 

--- a/facefind/utils.py
+++ b/facefind/utils.py
@@ -4,9 +4,10 @@ This module centralizes small helpers used across multiple scripts:
 
 * :func:`is_image` – quick predicate for image paths.
 * :func:`sanitize_label` – normalize labels for filesystem safety.
+* :func:`ensure_dir` – create directories as needed.
 
-The canonical file-extension set lives in :mod:`utils.common` and is imported
-here for convenience.
+The canonical file-extension set and :func:`ensure_dir` live in
+:mod:`utils.common` and are imported here for convenience.
 """
 from __future__ import annotations
 
@@ -14,7 +15,9 @@ import os
 import re
 from pathlib import Path
 
-from utils.common import IMAGE_EXTS
+from utils.common import IMAGE_EXTS, ensure_dir
+
+__all__ = ["IMAGE_EXTS", "ensure_dir", "is_image", "sanitize_label"]
 
 
 def is_image(p: Path) -> bool:

--- a/facefind/verify_crops.py
+++ b/facefind/verify_crops.py
@@ -18,7 +18,7 @@ from PIL import Image
 from facefind.config import get_profile
 from facefind.embedding_utils import get_device
 from facefind.quality import passes_quality
-from utils.common import ensure_dir
+from facefind.utils import ensure_dir
 
 
 logger = logging.getLogger(__name__)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import os
+from pathlib import Path
 
-from facefind.utils import sanitize_label
+from facefind.utils import IMAGE_EXTS, ensure_dir, is_image, sanitize_label
 
 
 def test_sanitize_label_replaces_separators():
@@ -41,3 +42,15 @@ def test_sanitize_label_special_chars_and_dots():
 def test_sanitize_label_max_length():
     long_label = "a" * 150
     assert len(sanitize_label(long_label)) == 100
+
+
+def test_ensure_dir_creates_directory(tmp_path):
+    target = tmp_path / "nested/dir"
+    ensure_dir(target)
+    assert target.is_dir()
+
+
+def test_is_image_respects_exts():
+    for ext in IMAGE_EXTS:
+        assert is_image(Path(f"file{ext}"))
+    assert not is_image(Path("file.txt"))


### PR DESCRIPTION
## Summary
- expose `ensure_dir` and `IMAGE_EXTS` via `facefind.utils`
- refactor scripts to import shared helpers from `facefind.utils`
- extend util tests to cover directory creation and image extension handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7b5bfa810832e8500eee98682b70c