### PR TITLE
feat: defer heavy deps

### DIFF
--- a/tests/test_embedding_utils.py
+++ b/tests/test_embedding_utils.py
@@ -1,5 +1,6 @@
-import sys
 from types import SimpleNamespace
+import sys
+from PIL import Image
 
 # Stub heavy dependencies before importing embedding_utils
 sys.modules["torch"] = SimpleNamespace(
@@ -8,25 +9,26 @@ sys.modules["torch"] = SimpleNamespace(
 )
 sys.modules["facenet_pytorch"] = SimpleNamespace(InceptionResnetV1=object)
 
-from PIL import Image
-
 import facefind.embedding_utils as embedding_utils
 
 
 def test_get_device_prefers_cuda(monkeypatch):
-    monkeypatch.setattr(embedding_utils.torch.cuda, "is_available", lambda: True)
+    torch_stub = sys.modules["torch"]
+    monkeypatch.setattr(torch_stub.cuda, "is_available", lambda: True)
     assert embedding_utils.get_device() == "cuda"
 
 
 def test_get_device_prefers_mps(monkeypatch):
-    monkeypatch.setattr(embedding_utils.torch.cuda, "is_available", lambda: False)
-    monkeypatch.setattr(embedding_utils.torch.backends.mps, "is_available", lambda: True)
+    torch_stub = sys.modules["torch"]
+    monkeypatch.setattr(torch_stub.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(torch_stub.backends.mps, "is_available", lambda: True)
     assert embedding_utils.get_device() == "mps"
 
 
 def test_get_device_default_cpu(monkeypatch):
-    monkeypatch.setattr(embedding_utils.torch.cuda, "is_available", lambda: False)
-    monkeypatch.setattr(embedding_utils.torch.backends.mps, "is_available", lambda: False)
+    torch_stub = sys.modules["torch"]
+    monkeypatch.setattr(torch_stub.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(torch_stub.backends.mps, "is_available", lambda: False)
     assert embedding_utils.get_device() == "cpu"
 
 

--- a/tests/test_image_analysis_import.py
+++ b/tests/test_image_analysis_import.py
@@ -1,0 +1,24 @@
+import importlib
+import builtins
+import sys
+
+
+def test_import_image_analysis_without_optional_dependencies(monkeypatch):
+    missing = {"cv2", "numpy", "torch", "PIL", "facenet_pytorch"}
+    for name in list(sys.modules):
+        if name.split('.')[0] in missing:
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.split('.')[0] in missing:
+            raise ModuleNotFoundError(name)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "facefind.embedding_utils", raising=False)
+    monkeypatch.delitem(sys.modules, "facefind.image_analysis", raising=False)
+
+    module = importlib.import_module("facefind.image_analysis")
+    assert module is not None


### PR DESCRIPTION
## Summary
- Load torch, Pillow, NumPy, and related heavy libraries only inside the functions that need them.
- Provide clear ImportError messages when optional dependencies are missing.
- Add regression test ensuring `facefind.image_analysis` imports even if those packages are absent.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7b7f4bef4832e9cde1d77675c58b8