### PR TITLE
Add tests for CSV header detection and path resolution

### DIFF
--- a/tests/test_apply_predictions.py
+++ b/tests/test_apply_predictions.py
@@ -1,0 +1,41 @@
+import csv
+import sys
+
+from facefind import apply_predictions
+
+
+def test_apply_predictions_header_and_placement(tmp_path, monkeypatch):
+    img1 = tmp_path / "a.jpg"
+    img2 = tmp_path / "b.jpg"
+    img3 = tmp_path / "c.jpg"
+    for img, text in [(img1, "a"), (img2, "b"), (img3, "c")]:
+        img.write_text(text)
+    csv_path = tmp_path / "preds.csv"
+    with csv_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["file", "prediction", "score"])
+        writer.writerow(["a.jpg", "alice", "0.9"])
+        writer.writerow(["b.jpg", "bob", "0.6"])
+        writer.writerow(["c.jpg", "carol", "0.2"])
+    with csv_path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        cols = apply_predictions.detect_headers(reader.fieldnames)
+    assert cols == ("file", "prediction", "score")
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "apply_predictions",
+            str(csv_path),
+            "--out-dir",
+            str(out_dir),
+            "--rel-root",
+            str(tmp_path),
+        ],
+    )
+    apply_predictions.main()
+    assert (out_dir / "accept" / "alice" / "a.jpg").exists()
+    assert (out_dir / "review" / "bob" / "b.jpg").exists()
+    assert not (out_dir / "accept" / "carol" / "c.jpg").exists()
+    assert not (out_dir / "review" / "carol" / "c.jpg").exists()

--- a/tests/test_split_clusters.py
+++ b/tests/test_split_clusters.py
@@ -21,3 +21,31 @@ def test_split_clusters_streams_large_csv(tmp_path, monkeypatch):
     current, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
     assert peak < 10 * 1024 * 1024  # peak memory stays under 10MB
+
+
+def test_split_clusters_places_files(tmp_path, monkeypatch):
+    img1 = tmp_path / "a.jpg"
+    img2 = tmp_path / "b.jpg"
+    img1.write_text("a")
+    img2.write_text("b")
+    csv_path = tmp_path / "small.csv"
+    with csv_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["image", "prediction"])
+        writer.writerow(["a.jpg", "foo"])
+        writer.writerow(["b.jpg", "bar"])
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "split_clusters",
+            str(csv_path),
+            str(out_dir),
+            "--rel-root",
+            str(tmp_path),
+        ],
+    )
+    split_clusters.main()
+    assert (out_dir / "foo" / "a.jpg").exists()
+    assert (out_dir / "bar" / "b.jpg").exists()


### PR DESCRIPTION
## Summary
- test apply_predictions for header detection, path resolution, and accept/review placement
- test split_clusters path resolution and per-label file placement

## Testing
- `pytest tests/test_apply_predictions.py tests/test_split_clusters.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7baf59ca8832e99afb49208d4f912