### PR TITLE
Validate thresholds for apply_predictions CLI

### DIFF
--- a/facefind/apply_predictions.py
+++ b/facefind/apply_predictions.py
@@ -82,12 +82,31 @@ def main():
     ap.add_argument("csv_path", help="CSV with columns path,label,prob (header flexible)")
     ap.add_argument("--people-dir", default=None, help="If set, accepted items also link/copy to this labeled people tree (people_by_cluster)")
     ap.add_argument("--out-dir", default="outputs/autosort", help="Where to place accept/review results (default: outputs/autosort)")
-    ap.add_argument("--accept-threshold", type=float, default=0.80, help="Confidence >= this goes to ACCEPT (default: 0.80)")
-    ap.add_argument("--review-threshold", type=float, default=0.50, help="Confidence >= this and < accept-threshold goes to REVIEW (default: 0.50)")
+    ap.add_argument(
+        "--accept-threshold",
+        type=float,
+        default=0.80,
+        help="Confidence >= this goes to ACCEPT (default: 0.80, range 0.0-1.0)",
+    )
+    ap.add_argument(
+        "--review-threshold",
+        type=float,
+        default=0.50,
+        help=(
+            "Confidence >= this and < accept-threshold goes to REVIEW "
+            "(default: 0.50, range 0.0-1.0)"
+        ),
+    )
     ap.add_argument("--copy", action="store_true", help="Copy files instead of creating hard links")
     ap.add_argument("--rel-root", default=None, help="Resolve relative CSV paths against this root (optional)")
     ap.add_argument("--log-level", default="INFO", help="Logging level (e.g., DEBUG, INFO)")
     args = ap.parse_args()
+    for name in ("accept_threshold", "review_threshold"):
+        val = getattr(args, name)
+        if not 0.0 <= val <= 1.0:
+            raise SystemExit(
+                f"{name.replace('_', '-')} must be between 0.0 and 1.0; got {val}"
+            )
 
     level = getattr(logging, args.log_level.upper(), logging.INFO)
     logging.basicConfig(level=level, force=True)


### PR DESCRIPTION
## Summary
- enforce 0-1 range on accept/review thresholds in apply_predictions
- document valid threshold range in CLI help
- test threshold boundary and error cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7bdd2966c832ea1d71298f821f75e