### PR TITLE
Add tests for prediction application and classifier training

### DIFF
--- a/tests/test_apply_predictions.py
+++ b/tests/test_apply_predictions.py
@@ -4,23 +4,30 @@ import sys
 from facefind import apply_predictions
 
 
-def test_apply_predictions_header_and_placement(tmp_path, monkeypatch):
+def test_detect_headers_synonyms():
+    headers = ["Image", "Pred_Label", "Confidence"]
+    assert apply_predictions.detect_headers(headers) == (
+        "Image",
+        "Pred_Label",
+        "Confidence",
+    )
+
+
+def test_apply_predictions_label_sanitization_and_placement(tmp_path, monkeypatch):
     img1 = tmp_path / "a.jpg"
     img2 = tmp_path / "b.jpg"
     img3 = tmp_path / "c.jpg"
     for img, text in [(img1, "a"), (img2, "b"), (img3, "c")]:
         img.write_text(text)
+
     csv_path = tmp_path / "preds.csv"
     with csv_path.open("w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["file", "prediction", "score"])
-        writer.writerow(["a.jpg", "alice", "0.9"])
-        writer.writerow(["b.jpg", "bob", "0.6"])
-        writer.writerow(["c.jpg", "carol", "0.2"])
-    with csv_path.open(newline="") as f:
-        reader = csv.DictReader(f)
-        cols = apply_predictions.detect_headers(reader.fieldnames)
-    assert cols == ("file", "prediction", "score")
+        writer.writerow(["a.jpg", "al/ice", "0.9"])
+        writer.writerow(["b.jpg", "bo b", "0.6"])
+        writer.writerow(["c.jpg", "ca r/ol", "0.2"])
+
     out_dir = tmp_path / "out"
     monkeypatch.setattr(
         sys,
@@ -35,7 +42,14 @@ def test_apply_predictions_header_and_placement(tmp_path, monkeypatch):
         ],
     )
     apply_predictions.main()
-    assert (out_dir / "accept" / "alice" / "a.jpg").exists()
-    assert (out_dir / "review" / "bob" / "b.jpg").exists()
-    assert not (out_dir / "accept" / "carol" / "c.jpg").exists()
-    assert not (out_dir / "review" / "carol" / "c.jpg").exists()
+
+    # high confidence → accept
+    assert (out_dir / "accept" / "al_ice" / "a.jpg").exists()
+
+    # mid confidence → review
+    assert (out_dir / "review" / "bo_b" / "b.jpg").exists()
+
+    # low confidence → ignored
+    assert not (out_dir / "accept" / "ca_r_ol" / "c.jpg").exists()
+    assert not (out_dir / "review" / "ca_r_ol" / "c.jpg").exists()
+

--- a/tests/test_train_face_classifier.py
+++ b/tests/test_train_face_classifier.py
@@ -1,0 +1,79 @@
+import json
+import sys
+from pathlib import Path
+
+import joblib
+import numpy as np
+import pytest
+from sklearn.neighbors import KNeighborsClassifier
+
+from facefind import train_face_classifier
+
+
+def test_train_face_classifier_artifacts_and_cv(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    for person in ["alice", "bob"]:
+        d = data_dir / person
+        d.mkdir(parents=True)
+        (d / f"{person}1.jpg").write_bytes(b"1")
+        (d / f"{person}2.jpg").write_bytes(b"1")
+
+    out_dir = tmp_path / "models"
+
+    def fake_load_images(paths):
+        return [object()] * len(paths)
+
+    def fake_embed_images(imgs, device=None, batch_size=None):
+        return np.array(
+            [
+                [1.0, 0.0],
+                [1.0, 0.0],
+                [0.0, 1.0],
+                [0.0, 1.0],
+            ],
+            dtype=np.float32,
+        )
+
+    def fake_get_device(preferred=None):
+        return "cpu"
+
+    def fake_cv(clf, X, y, cv=None, scoring=None):
+        if isinstance(clf, KNeighborsClassifier):
+            return np.array([0.9, 0.9])
+        return np.array([0.6, 0.6])
+
+    monkeypatch.setattr(train_face_classifier, "load_images", fake_load_images)
+    monkeypatch.setattr(train_face_classifier, "embed_images", fake_embed_images)
+    monkeypatch.setattr(train_face_classifier, "get_device", fake_get_device)
+    monkeypatch.setattr(train_face_classifier, "cross_val_score", fake_cv)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["train_face_classifier", "--data", str(data_dir), "--out", str(out_dir)],
+    )
+    train_face_classifier.main()
+
+    required = [
+        "face_classifier.joblib",
+        "labelmap.json",
+        "centroids.json",
+        "embeddings.npy",
+        "train_paths.json",
+        "train_labels.json",
+    ]
+    for name in required:
+        assert (out_dir / name).exists()
+
+    with (out_dir / "labelmap.json").open() as f:
+        labelmap = json.load(f)
+    assert labelmap == {"alice": 0, "bob": 1}
+
+    with (out_dir / "centroids.json").open() as f:
+        centroids = json.load(f)
+    assert centroids["alice"] == pytest.approx([1.0, 0.0])
+    assert centroids["bob"] == pytest.approx([0.0, 1.0])
+
+    model = joblib.load(out_dir / "face_classifier.joblib")
+    assert isinstance(model, KNeighborsClassifier)
+


### PR DESCRIPTION
## Summary
- expand tests for apply_predictions: verify header detection, label sanitization, and file placement
- add training test mocking embeddings and cross-validation to validate artifacts and model choice

## Testing
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_68b7c01a69e8832ea72eba1dbaab0a01