### PR TITLE
Add repo hygiene config and guardrails

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,12 @@ dist/
 
 # local data
 data/
+# Project artifacts
+outputs/
+models/
+.DS_Store
+
+# Tools & caches
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 <Your Name or Organization>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -120,5 +120,5 @@ pytest
 ---
 
 ## License
-MIT © 2025 <Your Name or Organization>
-See [`LICENSE`](LICENSE).
+
+This project is licensed under the [MIT License](LICENSE).

--- a/scripts/sanity_check.sh
+++ b/scripts/sanity_check.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python -m compileall -q -x '(^|/)(\.git|venv)(/|$)|(^|/)(outputs|data|models)(/|$)' .
+ruff check .
+ruff format --check .
+pytest -q


### PR DESCRIPTION
## Summary
- Expand `.gitignore` to cover project artifacts and common tool caches
- Add `.gitattributes` and MIT `LICENSE`
- Provide `scripts/sanity_check.sh` and reference license from README

## Testing
- `bash scripts/sanity_check.sh` *(fails: import ordering and undefined names from ruff)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c7f8a704832e82e87cd57681aebe