### PR TITLE
Harmonize CLI entrypoints and shared flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,53 +30,53 @@ facefind-detect \
   --input /PATH/TO/MEDIA \
   --output ./outputs \
   --video-step 5 \
-  --strictness strict
+  --config-profile strict
 ```
 
 **Verify crops (reject low-quality / non-faces):**
 ```bash
 facefind-verify \
-  outputs/crops \
+  --input outputs/crops \
   --reject-dir outputs/rejects \
-  --strictness strict
+  --config-profile strict
 ```
 
 **Split a clustering/prediction CSV into per-label folders (optional):**
 ```bash
 facefind-split \
-  outputs/clusters.csv \
-  outputs/people_by_cluster \
+  --input outputs/clusters.csv \
+  --output outputs/people_by_cluster \
   --copy
 ```
 
 **Train a classifier on labeled folders:**
 ```bash
 facefind-train \
-  --data outputs/people_by_cluster \
-  --out models
+  --input outputs/people_by_cluster \
+  --models-dir models
 ```
 
 **Predict on new crops / folders:**
 ```bash
 facefind-predict \
-  outputs/crops \
-  --model-dir models \
-  --out outputs/predictions.csv
+  --input outputs/crops \
+  --models-dir models \
+  --output outputs/predictions.csv
 ```
 
 **Apply predictions to accept/review folders (optional):**
 ```bash
 facefind-apply \
-  --in outputs/predictions.csv \
+  --input outputs/predictions.csv \
   --people-dir outputs/people \
-  --out-dir outputs/sorted
+  --output outputs/sorted
 ```
 
 ---
 
 ## Strictness Profiles (centralized in `facefind/config.py`)
 
-Use a single flag everywhere: `--strictness {strict,normal,loose}`.
+Use a single flag everywhere: `--config-profile {strict,normal,loose}`.
 
 | Profile | MTCNN Thresholds (pnet / rnet / onet) | Min Face Size | Min Prob | Embed Batch |
 |---|---|---|---|---|
@@ -90,7 +90,7 @@ Use a single flag everywhere: `--strictness {strict,normal,loose}`.
 
 ## Troubleshooting
 
-- **False positives (e.g., crops of shirts):** use `--strictness strict` or raise `--min-prob 0.95` and `--min-size 60`.
+- **False positives (e.g., crops of shirts):** use `--config-profile strict` or raise `--min-prob 0.95` and `--min-size 60`.
 - **Killed with exit code 137 (OOM):** reduce dataset / run in shards, lower `--embed-batch` (e.g., 32), or try `strict` profile.
 - **kNN CV error with tiny classes:** ensure ≥3 samples per class or favor SVM fallback.
 - **Slow detection:** switch hardware backend to GPU/MPS if available; consider RetinaFace/InsightFace in roadmap.

--- a/facefind/__init__.py
+++ b/facefind/__init__.py
@@ -1,8 +1,15 @@
 """FaceFind package with shared utilities and CLI entry points."""
 
+from importlib.metadata import PackageNotFoundError, version
+
 # Re-export common schema definitions for convenience when importing the
 # package directly (``import facefind``).
 from . import io_schema
 
-__all__ = ["io_schema"]
+try:  # pragma: no cover - importlib.metadata uses environment
+    __version__ = version("facefind")
+except PackageNotFoundError:  # pragma: no cover - during local editing
+    __version__ = "0.0.0"
+
+__all__ = ["io_schema", "__version__"]
 

--- a/facefind/cli_common.py
+++ b/facefind/cli_common.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from facefind import __version__
+
+LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR"]
+DEVICES = ["auto", "cpu", "mps", "cuda"]
+PROFILES = ["strict", "normal", "loose"]
+
+
+def add_version(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--version", action="version", version=f"facefind {__version__}")
+
+
+def add_log_level(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=LOG_LEVELS,
+        type=str.upper,
+        help="Set logging level",
+    )
+
+
+def add_device(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--device",
+        default="auto",
+        choices=DEVICES,
+        type=str.lower,
+        help="Computation device",
+    )
+
+
+def add_config_profile(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--config-profile",
+        default="strict",
+        choices=PROFILES,
+        type=str.lower,
+        help="Configuration profile",
+    )
+
+
+def validate_path(path: Path, *, kind: str) -> Path:
+    if not path.exists():
+        raise SystemExit(f"{kind} path does not exist: {path}")
+    return path

--- a/facefind/embedding_utils.py
+++ b/facefind/embedding_utils.py
@@ -19,7 +19,7 @@ T = TypeVar("T")
 # -------------------------
 # Device selection
 # -------------------------
-def get_device(preferred: Optional[str] = None) -> str:
+def get_device(preferred: Optional[str] = "auto") -> str:
     """
     Decide which torch device to use.
     Honors a user-preferred value if available; otherwise auto-selects.
@@ -29,17 +29,19 @@ def get_device(preferred: Optional[str] = None) -> str:
     except ModuleNotFoundError as e:
         raise ImportError("torch is required for get_device()") from e
 
-    if preferred:
-        pref = preferred.lower()
-        allowed = {"cpu", "cuda", "mps"}
-        if pref not in allowed:
-            raise ValueError(f"Unknown device '{preferred}'. Allowed: {sorted(allowed)}")
-        if pref == "cuda" and torch.cuda.is_available():
-            return "cuda"
-        if pref == "mps" and getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
-            return "mps"
+    pref = (preferred or "auto").lower()
+    allowed = {"auto", "cpu", "cuda", "mps"}
+    if pref not in allowed:
+        raise ValueError(f"Unknown device '{preferred}'. Allowed: {sorted(allowed)}")
+
+    if pref == "cuda" and torch.cuda.is_available():
+        return "cuda"
+    if pref == "mps" and getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+        return "mps"
+    if pref == "cpu":
         return "cpu"
 
+    # Auto-detect
     if torch.cuda.is_available():
         return "cuda"
     if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():

--- a/facefind/utils.py
+++ b/facefind/utils.py
@@ -6,8 +6,8 @@ This module centralizes small helpers used across multiple scripts:
 * :func:`sanitize_label` – normalize labels for filesystem safety.
 * :func:`ensure_dir` – create directories as needed.
 
-The canonical file-extension set and :func:`ensure_dir` live in
-:mod:`utils.common` and are imported here for convenience.
+The canonical file-extension set is defined here to avoid heavy imports at CLI
+startup.
 """
 from __future__ import annotations
 
@@ -15,7 +15,13 @@ import os
 import re
 from pathlib import Path
 
-from utils.common import IMAGE_EXTS, ensure_dir
+IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp"}
+
+
+def ensure_dir(p: Path) -> None:
+    """Ensure directory *p* exists, creating parents if needed."""
+    p.mkdir(parents=True, exist_ok=True)
+
 
 __all__ = ["IMAGE_EXTS", "ensure_dir", "is_image", "sanitize_label"]
 

--- a/tests/test_apply_predictions.py
+++ b/tests/test_apply_predictions.py
@@ -34,8 +34,9 @@ def test_apply_predictions_label_sanitization_and_placement(tmp_path, monkeypatc
         "argv",
         [
             "apply_predictions",
+            "--input",
             str(csv_path),
-            "--out-dir",
+            "--output",
             str(out_dir),
             "--rel-root",
             str(tmp_path),

--- a/tests/test_log_level.py
+++ b/tests/test_log_level.py
@@ -9,7 +9,19 @@ def test_log_level_debug_enables_debug_logs(tmp_path, monkeypatch, caplog):
     csv_path = tmp_path / "data.csv"
     csv_path.write_text(f"path,label\n{img},p1\n")
     out_dir = tmp_path / "out"
-    monkeypatch.setattr(sys, "argv", ["split_clusters", str(csv_path), str(out_dir), "--log-level", "DEBUG"])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "split_clusters",
+            "--input",
+            str(csv_path),
+            "--output",
+            str(out_dir),
+            "--log-level",
+            "DEBUG",
+        ],
+    )
     split_clusters.main()
     logging.getLogger().addHandler(caplog.handler)
     logging.getLogger().setLevel(logging.DEBUG)

--- a/tests/test_main_helpers.py
+++ b/tests/test_main_helpers.py
@@ -1,3 +1,4 @@
+import sys
 from types import SimpleNamespace
 from pathlib import Path
 
@@ -47,7 +48,7 @@ def test_create_mtcnn_uses_cpu_on_mps(monkeypatch):
                 device=device,
             )
 
-    monkeypatch.setattr(main, "MTCNN", DummyMTCNN)
+    monkeypatch.setitem(sys.modules, "facenet_pytorch", SimpleNamespace(MTCNN=DummyMTCNN))
 
     _ = main.create_mtcnn(prof, device="mps")
     assert captured["device"] == "cpu"

--- a/tests/test_resource_warnings.py
+++ b/tests/test_resource_warnings.py
@@ -44,7 +44,9 @@ def test_verify_crops_no_resource_warning(tmp_path, monkeypatch):
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        monkeypatch.setattr(sys, "argv", ["verify_crops", str(tmp_path)])
+        monkeypatch.setattr(
+            sys, "argv", ["verify_crops", "--input", str(tmp_path)]
+        )
         verify_crops.main()
 
     assert not _no_resource_warnings(w)

--- a/tests/test_split_clusters.py
+++ b/tests/test_split_clusters.py
@@ -16,7 +16,9 @@ def test_split_clusters_streams_large_csv(tmp_path, monkeypatch):
     out_dir = tmp_path / "out"
 
     tracemalloc.start()
-    monkeypatch.setattr(sys, "argv", ["split_clusters", str(csv_path), str(out_dir)])
+    monkeypatch.setattr(
+        sys, "argv", ["split_clusters", "--input", str(csv_path), "--output", str(out_dir)]
+    )
     split_clusters.main()
     current, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
@@ -40,7 +42,9 @@ def test_split_clusters_places_files(tmp_path, monkeypatch):
         "argv",
         [
             "split_clusters",
+            "--input",
             str(csv_path),
+            "--output",
             str(out_dir),
             "--rel-root",
             str(tmp_path),

--- a/tests/test_train_face_classifier.py
+++ b/tests/test_train_face_classifier.py
@@ -57,7 +57,13 @@ def test_train_face_classifier_artifacts_and_cv(tmp_path: Path, monkeypatch: pyt
     monkeypatch.setattr(
         sys,
         "argv",
-        ["train_face_classifier", "--data", str(data_dir), "--out", str(out_dir)],
+        [
+            "train_face_classifier",
+            "--input",
+            str(data_dir),
+            "--models-dir",
+            str(out_dir),
+        ],
     )
     train_face_classifier.main()
 


### PR DESCRIPTION
## Summary
- centralize common CLI flags and version handling
- add consistent argument parsing and path validation across facefind commands
- support automatic device selection with new `--device` values

## Testing
- `facefind-detect --help`
- `facefind-train --help`
- `facefind-apply --help`
- `python -c "import facefind.main"`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7c92f7cc4832e8204f94999be002d