### PR TITLE
refactor: avoid side effects on import

### DIFF
--- a/facefind/verify_crops.py
+++ b/facefind/verify_crops.py
@@ -9,9 +9,6 @@ import logging
 import shutil
 from pathlib import Path
 
-from facenet_pytorch import MTCNN
-from PIL import Image
-
 from facefind.cli_common import (
     add_config_profile,
     add_device,
@@ -64,6 +61,9 @@ def main(argv: list[str] | None = None) -> int:
     if device == "mps":
         logger.info("Detectors on MPS can fail due to adaptive pooling. Using CPU for MTCNN.")
         mtcnn_device = "cpu"
+
+    from facenet_pytorch import MTCNN  # local import to avoid side effects on import
+    from PIL import Image  # noqa: WPS433 - imported lazily
 
     mtcnn = MTCNN(
         keep_all=True,


### PR DESCRIPTION
## Summary
- lazily load cv2 and numpy in main via helper function to prevent import-time device checks
- defer cv2 import in quality module using sentinel to avoid heavy dependency on import
- move MTCNN and PIL imports into verify_crops main to avoid side effects at module load

## Testing
- `python - <<'PY'
import facefind, facefind.main
print('OK')
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7d33b1c48832eb1c8f507ec7fb75e