### PR TITLE
Skip .venv in sanity check

### DIFF
--- a/scripts/sanity_check.sh
+++ b/scripts/sanity_check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-python -m compileall -q -x '(^|/)(\.git|venv)(/|$)|(^|/)(outputs|data|models)(/|$)' .
+python -m compileall -q -x '(^|/)(\.git|\.venv)(/|$)|(^|/)(outputs|data|models)(/|$)' .
 ruff check .
 ruff format --check .
 pytest -q


### PR DESCRIPTION
## Summary
- ensure sanity check ignores `.venv` directories during bytecode compilation

## Testing
- `./scripts/sanity_check.sh` *(fails: Would reformat: facefind/main.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d7c72554832e93eaccdf783741ce