### PR TITLE
Defer heavy CLI imports and add helpful dependency errors

### DIFF
--- a/facefind/verify_crops.py
+++ b/facefind/verify_crops.py
@@ -62,8 +62,14 @@ def main(argv: list[str] | None = None) -> int:
         logger.info("Detectors on MPS can fail due to adaptive pooling. Using CPU for MTCNN.")
         mtcnn_device = "cpu"
 
-    from facenet_pytorch import MTCNN  # local import to avoid side effects on import
-    from PIL import Image  # noqa: WPS433 - imported lazily
+    try:
+        from facenet_pytorch import MTCNN  # local import to avoid side effects on import
+        from PIL import Image  # imported lazily
+    except Exception as e:
+        raise SystemExit(
+            "facenet-pytorch and Pillow are required. "
+            "Install with `pip install -r requirements.txt`."
+        ) from e
 
     mtcnn = MTCNN(
         keep_all=True,


### PR DESCRIPTION
## Summary
- lazy-load Pillow and cv2/NumPy in `facefind-detect` with friendly install guidance
- ensure `verify_crops`, `train_face_classifier`, and `predict_face` import heavy deps only when executed
- add user-friendly messages suggesting `pip install -r requirements.txt` if deps missing

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`
- `python -m facefind.main --help`
- `python -m facefind.verify_crops --help`
- `python -m facefind.train_face_classifier --help`
- `python -m facefind.predict_face --help`


------
https://chatgpt.com/codex/tasks/task_e_68b7d930fdd0832e98c4aa83617cfd86