### PR TITLE
Defer optional imports across FaceFind modules

### DIFF
--- a/facefind/gui/image_grid.py
+++ b/facefind/gui/image_grid.py
@@ -2,9 +2,15 @@
 
 from pathlib import Path  # For handling file paths
 
-from PyQt6.QtCore import QSize, Qt
-from PyQt6.QtGui import QIcon, QPixmap
-from PyQt6.QtWidgets import QListWidget, QListWidgetItem, QVBoxLayout, QWidget
+try:  # pragma: no cover - optional dependency
+    from PyQt6.QtCore import QSize, Qt
+    from PyQt6.QtGui import QIcon, QPixmap
+    from PyQt6.QtWidgets import QListWidget, QListWidgetItem, QVBoxLayout, QWidget
+except ModuleNotFoundError as e:  # pragma: no cover
+    raise ImportError(
+        "PyQt6 is required for facefind.gui.image_grid."
+        " Install the 'PyQt6' package to use this module."
+    ) from e
 
 
 class ImageGrid(QWidget):

--- a/facefind/gui/main_window.py
+++ b/facefind/gui/main_window.py
@@ -4,28 +4,34 @@
 import sys
 from pathlib import Path
 
-from PyQt6.QtGui import QAction, QTextCursor
-from PyQt6.QtWidgets import (
-    QCheckBox,
-    QComboBox,
-    QDoubleSpinBox,
-    QFileDialog,
-    QFormLayout,
-    QHBoxLayout,
-    QLabel,
-    QLineEdit,
-    QListWidget,
-    QListWidgetItem,
-    QMainWindow,
-    QMessageBox,
-    QPushButton,
-    QSpinBox,
-    QSplitter,
-    QTabWidget,
-    QTextEdit,
-    QVBoxLayout,
-    QWidget,
-)
+try:  # pragma: no cover - optional dependency
+    from PyQt6.QtGui import QAction, QTextCursor
+    from PyQt6.QtWidgets import (
+        QCheckBox,
+        QComboBox,
+        QDoubleSpinBox,
+        QFileDialog,
+        QFormLayout,
+        QHBoxLayout,
+        QLabel,
+        QLineEdit,
+        QListWidget,
+        QListWidgetItem,
+        QMainWindow,
+        QMessageBox,
+        QPushButton,
+        QSpinBox,
+        QSplitter,
+        QTabWidget,
+        QTextEdit,
+        QVBoxLayout,
+        QWidget,
+    )
+except ModuleNotFoundError as e:  # pragma: no cover
+    raise ImportError(
+        "PyQt6 is required for facefind.gui.main_window."
+        " Install the 'PyQt6' package to use this module."
+    ) from e
 
 from facefind.utils import ensure_dir
 

--- a/facefind/gui/process_worker.py
+++ b/facefind/gui/process_worker.py
@@ -1,6 +1,12 @@
 """Qt worker object to manage subprocess execution."""
 
-from PyQt6.QtCore import QObject, QProcess, QProcessEnvironment, pyqtSignal
+try:  # pragma: no cover - optional dependency
+    from PyQt6.QtCore import QObject, QProcess, QProcessEnvironment, pyqtSignal
+except ModuleNotFoundError as e:  # pragma: no cover
+    raise ImportError(
+        "PyQt6 is required for facefind.gui.process_worker."
+        " Install the 'PyQt6' package to use this module."
+    ) from e
 
 
 class ProcessWorker(QObject):

--- a/facefind/gui/qt_app.py
+++ b/facefind/gui/qt_app.py
@@ -5,10 +5,6 @@ import sys
 import traceback
 from pathlib import Path
 
-from PyQt6.QtWidgets import QApplication
-
-from .main_window import MainWindow
-
 
 def install_excepthook():
     def _hook(exctype, value, tb):
@@ -19,6 +15,10 @@ def install_excepthook():
 
 
 def main():
+    from PyQt6.QtWidgets import QApplication
+
+    from .main_window import MainWindow
+
     install_excepthook()
     app = QApplication(sys.argv)
     app.setApplicationName("FaceFind")

--- a/facefind/main.py
+++ b/facefind/main.py
@@ -114,7 +114,13 @@ def create_mtcnn(profile, device: str):
         logger.info("Detectors on MPS can fail due to adaptive pooling. Using CPU for MTCNN.")
         mtcnn_device = "cpu"
 
-    from facenet_pytorch import MTCNN
+    try:  # pragma: no cover - import for optional dependency
+        from facenet_pytorch import MTCNN
+    except ModuleNotFoundError as e:  # pragma: no cover - optional dependency
+        raise ImportError(
+            "facenet_pytorch is required for MTCNN detection. "
+            "Install with `pip install -r requirements.txt`."
+        ) from e
 
     return MTCNN(
         keep_all=True,


### PR DESCRIPTION
## Summary
- Lazy-load NumPy and OpenCV in `quality` to avoid import-time failures.
- Guard `facenet_pytorch` and PyQt6 imports so modules import cleanly without optional deps.
- Localize GUI imports to runtime to prevent side effects.

## Testing
- `ruff check facefind/main.py facefind/quality.py facefind/gui/qt_app.py facefind/gui/image_grid.py facefind/gui/main_window.py facefind/gui/process_worker.py`
- `pytest`
- `PYTHONDONTWRITEBYTECODE=1 python - <<'PY'\nimport facefind\nimport facefind.main\nimport facefind.embedding_utils\nimport facefind.quality\nimport facefind.gui.qt_app\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68b7da96edc0832e8545f1672e671185